### PR TITLE
Add a field to the return selection on mutation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -389,7 +389,9 @@ function minimizeComment(client, commentId) {
         // provide the minimize/hide comment method.
         yield client.graphql(`
       mutation MinimizeComment($input: MinimizeCommentInput!) {
-        minimizeComment(input: $input)
+        minimizeComment(input: $input) {
+          clientMutationId
+        }
       }
     `, {
             input: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,7 +91,9 @@ async function minimizeComment(client: GitHubClient, commentId: number) {
   await client.graphql(
     `
       mutation MinimizeComment($input: MinimizeCommentInput!) {
-        minimizeComment(input: $input)
+        minimizeComment(input: $input) {
+          clientMutationId
+        }
       }
     `,
     {


### PR DESCRIPTION
It is needed to specify at least one field in the selection.