### PR TITLE
Create workflow that automatically generates JavaScript

### DIFF
--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -27,9 +27,13 @@ jobs:
 
       - run: npm run prepare
 
-      - id: diff
+      - name: Get word diff to see changes in dist/index.js
+        id: diff
         run: |
-          echo "GIT_DIFF=$(git diff --word-diff=porcelain --word-diff-regex=.)" >> $GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
+          git diff --word-diff=porcelain --word-diff-regex=. >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request with generated JavaScript
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -28,6 +28,7 @@ jobs:
           add-paths: dist/
           commit-message: Generate JavaScript
           author: GitHub <noreply@github.com>
+          branch: github-actions/generate-js
           title: Generate JavaScript
           body: |
             This Pull Request is opened automatically and contains generated JavaScript code based on pushed changes.

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
-          git diff --word-diff=porcelain --word-diff-regex=. | grep '^[+-]' >> $GITHUB_OUTPUT
+          git diff --word-diff=porcelain --word-diff-regex=. dist/index.js | grep '^[+-]' >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request with generated JavaScript

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -1,0 +1,32 @@
+name: 'Generate JavaScript code and open Pull request with it'
+
+on:
+  push:
+    branches:
+     - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - run: npm install
+
+      - run: npm run prepare
+
+      - name: Create Pull Request with generated JavaScript
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: /dist/
+          commit-message: Generate JavaScript
+          title: Generate JavaScript
+          body: |
+            This Pull Request is opened automatically and contains generated JavaScript code based on pushed changes.

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -29,7 +29,7 @@ jobs:
 
       - id: diff
         run: |
-          echo "GIT_DIFF=$(git diff --word-diff=porcelain --word-diff-regex=." >> $GITHUB_OUTPUT
+          echo "GIT_DIFF=$(git diff --word-diff=porcelain --word-diff-regex=.)" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request with generated JavaScript
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -2,8 +2,9 @@ name: 'Generate JavaScript code and open Pull request with it'
 
 on:
   push:
-    branches:
-     - '**'
+    branches-ignore:
+     - 'renovate/*'
+     - 'github-actions/generate-js/*'
 
 jobs:
   build:

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -43,7 +43,7 @@ jobs:
             Generate JavaScript based on ${{ github.sha }}
           author: GitHub <noreply@github.com>
           branch: github-actions/generate-js/${{ github.ref_name }}
-          title: Generate JavaScript
+          title: Generate JavaScript for branch ${{ github.ref_name }}
           body: |
             This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following:
             ```

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
-          git diff --word-diff=porcelain --word-diff-regex=. >> $GITHUB_OUTPUT
+          git diff --word-diff=porcelain --word-diff-regex=. | grep '^[+-]' >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request with generated JavaScript

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -43,7 +43,7 @@ jobs:
             Generate JavaScript based on ${{ github.sha }}
           author: GitHub <noreply@github.com>
           branch: github-actions/generate-js/${{ github.ref_name }}
-          title: Generate JavaScript for branch ${{ github.ref_name }}
+          title: Generate JavaScript for branch `${{ github.ref_name }}`
           body: |
             This pull pequest is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following (context excluded):
             ```

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -28,7 +28,7 @@ jobs:
           add-paths: dist/
           commit-message: Generate JavaScript
           author: GitHub <noreply@github.com>
-          branch: github-actions/generate-js
+          branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript
           body: |
             This Pull Request is opened automatically and contains generated JavaScript code based on pushed changes.

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
-          git diff --word-diff=porcelain --word-diff-regex=. dist/index.js | grep '^[+-]' >> $GITHUB_OUTPUT
+          git diff --word-diff=porcelain --word-diff-regex=. dist/ | grep '^[+-]' >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create pull request with generated JavaScript

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -27,6 +27,10 @@ jobs:
 
       - run: npm run prepare
 
+      - id: diff
+        run: |
+          echo "GIT_DIFF=$(git diff --word-diff=porcelain --word-diff-regex=." >> $GITHUB_OUTPUT
+
       - name: Create Pull Request with generated JavaScript
         uses: peter-evans/create-pull-request@v5
         with:
@@ -37,4 +41,7 @@ jobs:
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript
           body: |
-            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}.
+            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following:
+            ```
+            ${{ steps.diff.outputs.GIT_DIFF }}
+            ```

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create Pull Request with generated JavaScript
         uses: peter-evans/create-pull-request@v5
         with:
-          add-paths: /dist/
+          add-paths: dist/
           commit-message: Generate JavaScript
           title: Generate JavaScript
           body: |

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
      - 'renovate/*'
      - 'github-actions/generate-js/*'
+    paths-ignore:
+     - '.github/**'
+     - '**.md'
+     - 'action.yml'
 
 jobs:
   build:

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -31,7 +31,8 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: dist/
-          commit-message: Generate JavaScript
+          commit-message: |
+            Generate JavaScript based on ${{ github.sha }}
           author: GitHub <noreply@github.com>
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           add-paths: dist/
           commit-message: Generate JavaScript
+          author: GitHub <noreply@github.com>
           title: Generate JavaScript
           body: |
             This Pull Request is opened automatically and contains generated JavaScript code based on pushed changes.

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -1,4 +1,4 @@
-name: 'Generate JavaScript code and open Pull request with it'
+name: 'Generate JavaScript code and open pull request with it'
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
           git diff --word-diff=porcelain --word-diff-regex=. dist/index.js | grep '^[+-]' >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
-      - name: Create Pull Request with generated JavaScript
+      - name: Create pull request with generated JavaScript
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: dist/
@@ -45,7 +45,7 @@ jobs:
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript for branch ${{ github.ref_name }}
           body: |
-            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following (context excluded):
+            This pull pequest is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following (context excluded):
             ```
             ${{ steps.diff.outputs.GIT_DIFF }}
             ```

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -45,7 +45,7 @@ jobs:
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript for branch ${{ github.ref_name }}
           body: |
-            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following:
+            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}. The changes are the following (context excluded):
             ```
             ${{ steps.diff.outputs.GIT_DIFF }}
             ```

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -36,4 +36,4 @@ jobs:
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript
           body: |
-            This Pull Request is opened automatically and contains generated JavaScript code based on pushed changes.
+            This Pull Request is opened automatically and contains generated JavaScript code based on commit ${{ github.sha }}.

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20.6.1
           cache: npm
 
       - run: npm install

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -5,10 +5,6 @@ on:
     branches-ignore:
      - 'renovate/*'
      - 'github-actions/generate-js/*'
-    paths-ignore:
-     - '.github/**'
-     - '**.md'
-     - 'action.yml'
 
 jobs:
   build:

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20.6.1
+          node-version: 20
           cache: npm
 
       - run: npm install

--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -39,8 +39,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: dist/
-          commit-message: |
-            Generate JavaScript based on ${{ github.sha }}
+          commit-message: Generate JavaScript based on ${{ github.sha }}
           author: GitHub <noreply@github.com>
           branch: github-actions/generate-js/${{ github.ref_name }}
           title: Generate JavaScript for branch `${{ github.ref_name }}`


### PR DESCRIPTION
Whenever a change is pushed to a branch, this workflow will generate JavaScript and create PR if needed. It creates different PR branch `github-actions/generate-js/<base branch>` for each base branch. Multiple branches are supported to test changes in forks without changing the workflow.

Need to allow github-actions bot to write to the repo and to create PRs (Settings > Actions > General > Workflow permissions).

Maybe needs some polishing with text and branch naming.

Example: https://github.com/scb261/issue-moderator-action/pull/16

I'm thinking about eventually creating CONTIBUTING.md and putting this info in there, but idk if and when I'll do it.

Todo:
- [x] Ignore `renovate/*` and `github-actions/generate-js/*` branches
- [x] Ignore some paths (dist, .github, .md, etc.)
- [x] Show hash of the commit that was used to generate JS in PR body and in commit message
- [x] Play with `git diff --word-diff=` and maybe add it to PR body