### PR TITLE
Fix JS generation: Skip getting diff if there is no diff

### DIFF
--- a/.github/workflows/generate-js.yml
+++ b/.github/workflows/generate-js.yml
@@ -23,13 +23,16 @@ jobs:
 
       - run: npm run prepare
 
-      - name: Get word diff to see changes in dist/index.js
+      - name: Get word diff to see changes in dist folder
         id: diff
         run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
-          git diff --word-diff=porcelain --word-diff-regex=. dist/ | grep '^[+-]' >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
+          if ! git diff --quiet dist
+          then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "GIT_DIFF<<$EOF" >> $GITHUB_OUTPUT
+            git diff --word-diff=porcelain --word-diff-regex=. dist | grep '^[+-]' >> $GITHUB_OUTPUT
+            echo "$EOF" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create pull request with generated JavaScript
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Fixes failed status when there were no changes to the generated code, e.g. https://github.com/tachiyomiorg/issue-moderator-action/pull/400#issuecomment-1713710710.

- Example of no diff: https://github.com/scb261/issue-moderator-action/actions/runs/6148012822 which was successful and didn't open a PR.
- Example of diff: https://github.com/scb261/issue-moderator-action/actions/runs/6148038928 which was successful and did open a PR - https://github.com/scb261/issue-moderator-action/pull/18.